### PR TITLE
Exit with 1 if there are no matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Patch notes are automatically extracted from this changelog whenever a tag is
 pushed to the GitHub repository. The tag name must match a heading exactly.
 
 
+## Next Release
+
+- Exit with code 1 if no matches are found (#3, thanks @brennerm)
+
+
 ## v1.0.0
 
 The first proper release of `markdown-extract`! :tada:

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,8 +1,10 @@
 pub mod document;
+mod error;
 mod matchers;
 mod parser;
 
 use document::{Document, Section};
+use error::NoMatchesError;
 use matchers::{Matcher, RegexMatcher, SimpleMatcher};
 use parser::Parser;
 use std::convert::TryInto;
@@ -61,7 +63,6 @@ fn print_section(document: &Document, section: &Section, ignore_first_heading: b
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    // Get opts
     let opts = Opts::from_args();
 
     // Create parser and get file
@@ -76,20 +77,15 @@ fn run() -> Result<(), Box<dyn Error>> {
         SimpleMatcher::get_matches(&document, &opts)
     };
 
-    // Handle no matches
     if matches.is_empty() {
-        println!("No matches.");
-        return Ok(());
+        return Err(Box::new(NoMatchesError::new()));
     }
 
-    // Only print the first match
     if opts.first {
-        // It's okay to use `[0]` here since we check if the doc is empty above
         print_section(&document, &matches[0], opts.ignore_first_heading);
         return Ok(());
     }
 
-    // Print matching sections
     for section in matches {
         print_section(&document, &section, opts.ignore_first_heading);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,20 @@
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct NoMatchesError;
+
+impl NoMatchesError {
+    /// Constructs a new `NoMatchesError`
+    pub fn new() -> NoMatchesError {
+        NoMatchesError {}
+    }
+}
+
+impl fmt::Display for NoMatchesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "No matches.")
+    }
+}
+
+impl Error for NoMatchesError {}


### PR DESCRIPTION
This PR resolves #3, causing the program to exit with code 1 when no matches are found within the markdown document.