### PR TITLE
Create Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ pushed to the GitHub repository. The tag name must match a heading exactly.
 ## Next Release
 
 - Exit with code 1 if no matches are found (#3, thanks @brennerm)
+- Publish `markdown-extract` as a Docker image (#2, thanks @brennerm)
 
 
 ## v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.43
-
+FROM rust:1.43 as builder
 WORKDIR /usr/src/markdown-extract
 COPY . .
-
 RUN cargo install --path .
 
+FROM debian:buster-slim
+COPY --from=builder /usr/local/cargo/bin/markdown-extract /usr/local/bin/markdown-extract
 ENTRYPOINT ["markdown-extract"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.41
+FROM rust:1.43
 
 WORKDIR /usr/src/markdown-extract
 COPY . .
 
 RUN cargo install --path .
 
-CMD ["markdown-extract", "--help"]
+ENTRYPOINT ["markdown-extract"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.41
+
+WORKDIR /usr/src/markdown-extract
+COPY . .
+
+RUN cargo install --path .
+
+CMD ["markdown-extract"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . .
 
 RUN cargo install --path .
 
-CMD ["markdown-extract"]
+CMD ["markdown-extract", "--help"]

--- a/README.md
+++ b/README.md
@@ -4,14 +4,33 @@ Extract sections of a markdown file. This project mostly exists to help me learn
 Rust, and to fill a niche requirement for extracting patch notes from
 a `CHANGELOG.md`.
 
+## Installation
+
+If you've got Rust installed on your system, you can simple install
+`markdown-extract` with Cargo.
+
+```console
+$ cargo install markdown-extract 
+...
+```
+
+### Docker
+
+A Docker container is also available, and can be installed with the following
+command:
+
+```console
+$ docker pull sean0x42/markdown-extract
+```
+
+You can then run the container with the following command:
+
+```console
+$ docker run -it sean0x42/markdown-extract markdown-extract --help
+```
+
 
 ## Usage 
-
-Start by installing `markdown-extract`. Requires Cargo.
-
-```
-cargo install markdown-extract 
-```
 
 View the help guide if you like.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker pull sean0x42/markdown-extract
 You can then run the container with the following command:
 
 ```console
-$ docker run -it sean0x42/markdown-extract markdown-extract --help
+$ docker run -it sean0x42/markdown-extract --help
 ```
 
 


### PR DESCRIPTION
This pull request allows users to pull a docker image of `markdown-extract`.

The docker image has been uploaded to hub.docker.com, and should now automatically rebuild whenever code is pushed to `master`.

https://hub.docker.com/r/sean0x42/markdown-extract

Closes #2.