### PR TITLE
Use `actions/checkout@v2` in workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     
     - name: Install markdown-extract
       run: cargo install markdown-extract

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Version 1 of `actions/checkout` contains a vulnerability, and it is recommended to upgrade.

See #10 and #11 