### PR TITLE
Fail the Github Actions step when the command errors

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
 # process flags
@@ -15,4 +17,5 @@ if [ "$FLAG_NO_PRINT_MATCHED_HEADING" = "true" ]; then
 fi
 ARGUMENTS="$ARGUMENTS $*"
 
-{ echo "markdown<<$EOF"; /markdown-extract $ARGUMENTS; echo "$EOF"; } >> "$GITHUB_OUTPUT"
+/markdown-extract $ARGUMENTS 1>stdout
+{ echo "markdown<<$EOF"; cat stdout; echo "$EOF"; } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
With the `markdown-extract` command wrapped in a subshell, if it fails, the entrypoint script itself doesn't produce an error.

Instead, the `Error: No matches.` output of the command (which _should_ go to `stderr`, not `stdout`; separate issue [here](https://github.com/sean0x42/markdown-extract/issues/20)) ends up in the `markdown` output and the entire action step succeeds (when it _should_ fail).

Downstream steps can then produce odd results, like a Github release publisher step creating a release with the contents `Error: No matches.`.