### PR TITLE
Change sample workflow to use heredoc to more safely dump markdown to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Here is a sample workflow usage:
    pattern: 'v2.0.0'
 - name: Write output to file
   run: |
-    printf '${{ steps.extract-changelog.outputs.markdown }}' > CHANGELOG-extracted.txt
+    cat <<'EOF' > CHANGELOG-extracted.txt
+    ${{ steps.extract-changelog.outputs.markdown }}
+    EOF
 - uses: actions/upload-artifact@v3
   with:
    name: changelog


### PR DESCRIPTION
Updates the sample GitHub Actions workflow to improve the "Write output to file" step. The previous version of this step breaks if the markdown content contains an apostrophe—see #25.

The proposed version uses [heredoc](https://en.wikipedia.org/wiki/Here_document) to write out the file. Single quotes are used to avoid any variable substitution or backtick evaluation. 

Here's a demo of it working successfully:

<img src="https://github.com/user-attachments/assets/42e4cb1a-020c-4a70-854e-db521ad95104" width="640">

- [GitHub Actions workflow run](https://github.com/jayqi/gha-python-package-release-demo/actions/runs/13342406635/job/37268717883)
- [Input markdown](https://github.com/jayqi/gha-python-package-release-demo/blob/69c2db55b56a2a4eee1bf82467b87f47897c7bc9/CHANGELOG.md?plain=1#L5-L17)
- [Created release](https://github.com/jayqi/gha-python-package-release-demo/releases/tag/v0.2.0)